### PR TITLE
add live-config-module to vm

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -59,6 +59,7 @@
             services.getty.autologinUser = "root";
             virtualisation.forwardPorts = [{ from = "host"; host.port = 8000; guest.port = 80; }];
           }
+          live-config-module
         ];
       };
 


### PR DESCRIPTION
After the fast-deploy refactor, the local VM no longer contained the app.